### PR TITLE
skip matrix copy and directly load on ofImage (only for grayscale cam)

### DIFF
--- a/src/ofxAravis.h
+++ b/src/ofxAravis.h
@@ -56,7 +56,7 @@ public:
 
 private:
 	static void onNewBuffer(ArvStream *stream, ofxAravis* aravis);
-	void setPixels(cv::Mat& mat);
+	void setPixels(ArvBuffer *buffer, int w, int h, ofImageType imageType);
 
 	int targetX, targetY, targetWidth, targetHeight;
 	int x, y, width, height;
@@ -66,4 +66,7 @@ private:
 	std::atomic_bool bFrameNew;
 	ofImage image;
 	cv::Mat mat;
+	int w, h;
+	ofImageType imageType;
+	ArvBuffer *buffer;
 };


### PR DESCRIPTION
**don't merge until conditions for color cameras are impelemented**

this pr improves frame rate by skipping redundant matrix copies. I have tested with grayscale gige flir (pointgrey) camera but not with color cameras.

N